### PR TITLE
docs: sync AGENTS catalog counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # awesome claude notes (ECC) — Agent Instructions
 
-This is a **production-ready AI coding plugin** providing 28 specialized agents, 119 skills, 60 commands, and automated hook workflows for software development.
+This is a **production-ready AI coding plugin** providing 28 specialized agents, 125 skills, 60 commands, and automated hook workflows for software development.
 
 **Version:** 1.9.0
 
@@ -142,7 +142,7 @@ Troubleshoot failures: check test isolation → verify mocks → fix implementat
 
 ```
 agents/          — 28 specialized subagents
-skills/          — 117 workflow skills and domain knowledge
+skills/          — 125 workflow skills and domain knowledge
 commands/        — 60 slash commands
 hooks/           — Trigger-based automations
 rules/           — Always-follow guidelines (common + per-language)


### PR DESCRIPTION
## Summary
- update the AGENTS summary line to the current repository counts
- sync the project structure section from 117 skills to 125 skills
- reduce catalog drift between AGENTS.md and the actual repository contents

## Testing
- git diff --check