### PR TITLE
docs: add llms.txt for package metadata

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,24 @@
+# awesome claude notes
+
+> Production-ready AI coding workflow assets for Claude Code, Cursor, Codex, OpenCode, and related harnesses.
+
+Core docs:
+- README.md
+- AGENTS.md
+- docs/zh-CN/README.md
+- TROUBLESHOOTING.md
+- docs/SELECTIVE-INSTALL-ARCHITECTURE.md
+
+Core assets:
+- agents/
+- commands/
+- skills/
+- hooks/
+- rules/
+- mcp-configs/
+- manifests/
+
+CLI entrypoints:
+- npx ecc <language>
+- npx ecc-install <language>
+- node scripts/install-apply.js --profile <name>


### PR DESCRIPTION
## Summary
- add a top-level llms.txt file referenced by package.json
- describe the core docs, assets, and CLI entrypoints in a lightweight machine-readable index
- close the gap between the published package manifest and the repository tree

## Testing
- git diff --check