### PR TITLE
chore: add published .agents placeholder

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,9 @@
+# .agents placeholder
+
+This directory is intentionally published with the package because some harnesses and install manifests expect a `.agents/` root to exist.
+
+The canonical agent catalog for this repository remains:
+- `agents/`
+- `AGENTS.md`
+
+Files under `.agents/` can be generated or expanded by downstream tooling without requiring consumers to create the directory manually.


### PR DESCRIPTION
## Summary
- add a published .agents placeholder directory
- include a small README explaining why the directory exists
- satisfy install manifest expectations for a .agents root in the published package

## Testing
- NODE_PATH=/Users/youfanyu/Desktop/workspace/skills/awesome-claude-notes/node_modules node scripts/ci/validate-install-manifests.js