### PR TITLE
fix: skip incompatible antigravity manifest modules

### DIFF
--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -90,7 +90,6 @@
       "targets": [
         "claude",
         "cursor",
-        "antigravity",
         "codex",
         "opencode"
       ],
@@ -201,7 +200,6 @@
       "targets": [
         "claude",
         "cursor",
-        "antigravity",
         "codex",
         "opencode"
       ],


### PR DESCRIPTION
## Summary
- remove antigravity from the target lists for platform-configs and workflow-quality
- keep the core antigravity profile limited to modules the target can actually scaffold
- stop profile installs from copying incompatible skills/config modules into .agent

## Testing
- NODE_PATH=/Users/youfanyu/Desktop/workspace/skills/awesome-claude-notes/node_modules node tests/scripts/install-apply.test.js